### PR TITLE
use bytes.Buffer copy instead of make slice #2

### DIFF
--- a/cmd/dump/dump.go
+++ b/cmd/dump/dump.go
@@ -3,10 +3,13 @@
 package main
 
 import (
+	"bytes"
 	"encoding/csv"
-	"github.com/alldroll/cdb"
+	"io"
 	"log"
 	"os"
+
+	"github.com/alldroll/cdb"
 )
 
 func main() {
@@ -40,17 +43,15 @@ func main() {
 	for {
 		record := iterator.Record()
 
-		keyReader, keySize := record.Key()
-		key := make([]byte, keySize)
-		if _, err = keyReader.Read(key); err != nil {
-			log.Fatal(err)
-		}
+		keyReader, _ := record.Key()
+		keyBuf := new(bytes.Buffer)
+		io.Copy(keyBuf, keyReader)
+		key := keyBuf.Bytes()
 
-		valReader, valSize := record.Value()
-		value := make([]byte, valSize)
-		if _, err = valReader.Read(value); err != nil {
-			log.Fatal(err)
-		}
+		valReader, _ := record.Value()
+		valBuf := new(bytes.Buffer)
+		io.Copy(valBuf, valReader)
+		value := valBuf.Bytes()
 
 		err = csvWriter.Write([]string{string(key), string(value)})
 		if err != nil {


### PR DESCRIPTION
#2 
I fix to be using io.Copy from reader stream to byte.Buffer instead of making slice object.
And I would like to indicate memory usage performance. Let me how to measure the performance which you tested.